### PR TITLE
Fix inheritance in metadata base object creation

### DIFF
--- a/transpiler/index.js
+++ b/transpiler/index.js
@@ -1871,7 +1871,7 @@ function __PrepareMetadata(base, kind, property) {
   const createObjectWithPrototype = (obj, key) =>
     Object.hasOwnProperty.call(obj, key) ?
       obj[key] :
-      Object.create(obj[key] || {});
+      Object.create(obj[key] || Object.prototype);
   
   return {
     getMetadata(key) {


### PR DESCRIPTION
When creating a metadata object that is not inheriting from another metadata object, that object should inherit directly from Object.prototype ([reference (3.e.)](https://arai-a.github.io/ecma262-compare/?pr=2417&id=sec-convertdecoratormetadatalisttoobject)).  The previous implementation was using an empty object (`{}`) which created for the metadata object an empty object that inherited from another empty object that inherited from Object.prototype, adding an extra layer of inheritance.