### PR TITLE
Fix lost spacing in console time.

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -307,6 +307,7 @@ code {
   display     : block;
   float       : left;
   margin-left : 8px;
+  white-space : pre;
 }
 #console .msg {
   display : block;


### PR DESCRIPTION
There was a space after the log time in the console that was getting lost because of the applied float.  This space can be restored by making the time have a white-space of pre.

![image](https://user-images.githubusercontent.com/3536716/129782997-899db2b6-dcb2-4514-bf17-7e82105d595f.png)
